### PR TITLE
fix(types): add file extensions to avoid node16 resolution errors

### DIFF
--- a/.changeset/chubby-dolls-notice.md
+++ b/.changeset/chubby-dolls-notice.md
@@ -1,0 +1,5 @@
+---
+"@marcalexiei/fastify-type-provider-zod": patch
+---
+
+fix(types): add file extensions to avoid node16 resolution errors

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Ignored issues:
    (which supports 3.1)
 5. Using `swagger` object for OpenAPI standard throws an error instead of a warning
 6. Uses `vitest` typechecking rather than `tsd`
-7. Type test are run on node, node16, bundler module resolutions
+7. Type tests are run on `node`, `node16`, `bundler` module resolutions
 
 ## How to use?
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -4,11 +4,6 @@
   "linter": {
     "domains": {
       "project": "all"
-    },
-    "rules": {
-      "correctness": {
-        "useImportExtensions": "off"
-      }
     }
   },
   "overrides": [

--- a/src/core.ts
+++ b/src/core.ts
@@ -12,7 +12,8 @@ import type {
   RawServerBase,
   RawServerDefault,
 } from 'fastify';
-import type { FastifySerializerCompiler } from 'fastify/types/schema';
+// When https://github.com/fastify/fastify/pull/6207 is released when can import from fastify
+import type { FastifySerializerCompiler } from 'fastify/types/schema.js';
 import type { $ZodRegistry, input, output } from 'zod/v4/core';
 import { $ZodType, globalRegistry, safeParse } from 'zod/v4/core';
 
@@ -20,9 +21,9 @@ import {
   createValidationError,
   InvalidSchemaError,
   ResponseSerializationError,
-} from './errors';
-import { getOpenAPISchemaVersion } from './openapi';
-import { zodRegistryToJson, zodSchemaToJson } from './zod-to-json';
+} from './errors.ts';
+import { getOpenAPISchemaVersion } from './openapi.ts';
+import { zodRegistryToJson, zodSchemaToJson } from './zod-to-json.ts';
 
 const defaultSkipList = [
   '/documentation/',

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,7 @@
 import createError, { type FastifyErrorConstructor } from '@fastify/error';
 import type { FastifyError } from 'fastify';
-import type { FastifySchemaValidationError } from 'fastify/types/schema';
+// When https://github.com/fastify/fastify/pull/6207 is released when can import from fastify
+import type { FastifySchemaValidationError } from 'fastify/types/schema.js';
 import type { $ZodError } from 'zod/v4/core';
 
 export const InvalidSchemaError: FastifyErrorConstructor<

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export {
   validatorCompiler,
   type ZodSerializerCompilerOptions,
   type ZodTypeProvider,
-} from './core';
+} from './core.ts';
 
 export {
   hasZodFastifySchemaValidationErrors,
@@ -18,4 +18,4 @@ export {
   isResponseSerializationError,
   ResponseSerializationError,
   type ZodFastifySchemaValidationError,
-} from './errors';
+} from './errors.ts';

--- a/src/zod-to-json.ts
+++ b/src/zod-to-json.ts
@@ -3,7 +3,7 @@ import { $ZodRegistry, $ZodType, toJSONSchema } from 'zod/v4/core';
 import {
   convertSchemaToOpenAPISchemaVersion,
   type OpenAPISchemaVersion,
-} from './openapi';
+} from './openapi.ts';
 
 const getSchemaId = (id: string, io: 'input' | 'output') => {
   return io === 'input' ? `${id}Input` : id;

--- a/test-types/error.spec-d.ts
+++ b/test-types/error.spec-d.ts
@@ -1,10 +1,10 @@
-import type { FastifySchemaValidationError } from 'fastify/types/schema';
+import type { FastifySchemaValidationError } from 'fastify/types/schema.js';
 import { describe, expectTypeOf, it } from 'vitest';
 
 import {
   hasZodFastifySchemaValidationErrors,
   type ZodFastifySchemaValidationError,
-} from '../src/index';
+} from '../src/index.ts';
 
 describe('ZodFastifySchemaValidationError', () => {
   it('should be assignable to FastifySchemaValidationError', () => {

--- a/test-types/index.spec-d.ts
+++ b/test-types/index.spec-d.ts
@@ -8,8 +8,8 @@ import type {
 import Fastify from 'fastify';
 import { assertType, describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod/v4';
-import type { ZodTypeProvider } from '../src/index';
-import { serializerCompiler, validatorCompiler } from '../src/index';
+import type { ZodTypeProvider } from '../src/index.ts';
+import { serializerCompiler, validatorCompiler } from '../src/index.ts';
 
 describe('index', () => {
   it('FastifyZodInstance is compatible with FastifyInstance', () => {

--- a/test-types/plugin.spec-d.ts
+++ b/test-types/plugin.spec-d.ts
@@ -7,7 +7,7 @@ import z from 'zod/v4';
 import type {
   FastifyPluginAsyncZod,
   FastifyPluginCallbackZod,
-} from '../src/index';
+} from '../src/index.ts';
 
 describe('plugin', () => {
   it('ensure the defaults of FastifyPluginAsyncZod are the same as FastifyPluginAsync', () => {

--- a/test/request-schema-error-handler.spec.ts
+++ b/test/request-schema-error-handler.spec.ts
@@ -2,12 +2,12 @@ import type { FastifyInstance } from 'fastify';
 import Fastify from 'fastify';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
-import type { ZodTypeProvider } from '../src/index';
+import type { ZodTypeProvider } from '../src/index.ts';
 import {
   hasZodFastifySchemaValidationErrors,
   serializerCompiler,
   validatorCompiler,
-} from '../src/index';
+} from '../src/index.ts';
 
 describe('response schema with custom error handler', () => {
   let app: FastifyInstance;

--- a/test/request-schema.spec.ts
+++ b/test/request-schema.spec.ts
@@ -2,8 +2,8 @@ import type { FastifyInstance } from 'fastify';
 import Fastify from 'fastify';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
-import type { ZodTypeProvider } from '../src/index';
-import { serializerCompiler, validatorCompiler } from '../src/index';
+import type { ZodTypeProvider } from '../src/index.ts';
+import { serializerCompiler, validatorCompiler } from '../src/index.ts';
 
 describe('response schema', () => {
   let app: FastifyInstance;

--- a/test/response-schema.spec.ts
+++ b/test/response-schema.spec.ts
@@ -2,13 +2,13 @@ import type { FastifyInstance } from 'fastify';
 import Fastify from 'fastify';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
-import type { ZodTypeProvider } from '../src/index';
+import type { ZodTypeProvider } from '../src/index.ts';
 import {
   createSerializerCompiler,
   isResponseSerializationError,
   serializerCompiler,
   validatorCompiler,
-} from '../src/index';
+} from '../src/index.ts';
 
 describe('response schema', () => {
   describe('does not fail on empty response schema (204)', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
         [
           ['tsconfig.bundler.json', 'green'],
           ['tsconfig.node.json', 'magenta'],
-          // ['tsconfig.node16.json','cyan'],
+          ['tsconfig.node16.json', 'cyan'],
         ] as const
       ).map<TestProjectConfiguration>(([it, color]) => ({
         test: {


### PR DESCRIPTION
- closes #6 

`fastify` hasn't released the pr to expose relevant types (https://github.com/fastify/fastify/pull/6207) in a while.
As workaround I'm adding `.js` extension to `fastify/schema/types` imports that should resolve the issue.

---

To avoid similar problem in the future (and maybe speed up check a little bit)  I enabled the [`useImportExtensions` biome rule](https://biomejs.dev/linter/rules/use-import-extensions/)