### PR TITLE
fix(openapi): prune only unused schemas from `components.schemas`

### DIFF
--- a/.changeset/puny-toys-tie.md
+++ b/.changeset/puny-toys-tie.md
@@ -1,0 +1,5 @@
+---
+"@marcalexiei/fastify-type-provider-zod": patch
+---
+
+fix(openapi): prune only unused schemas from `components.schemas`

--- a/src/core.ts
+++ b/src/core.ts
@@ -24,7 +24,7 @@ import {
 } from './errors.ts';
 import { getOpenAPISchemaVersion } from './openapi.ts';
 import {
-  removeUnusedRefs,
+  removeUnusedSchemaRefs,
   zodRegistryToJson,
   zodSchemaToJson,
 } from './zod-to-json.ts';
@@ -176,7 +176,7 @@ export const createJsonSchemaTransformObject = (
       }
     }
 
-    return removeUnusedRefs({
+    return removeUnusedSchemaRefs({
       ...documentObject.openapiObject,
       components: {
         ...documentObject.openapiObject.components,

--- a/src/zod-to-json.ts
+++ b/src/zod-to-json.ts
@@ -195,7 +195,7 @@ function collectRefs(obj: unknown, refs = new Set<string>()): Set<string> {
   return refs;
 }
 
-export function removeUnusedRefs(
+export function removeUnusedSchemaRefs(
   spec: JSONSchema.BaseSchema,
 ): JSONSchema.BaseSchema {
   const usedRefs = collectRefs(spec.paths);
@@ -206,7 +206,14 @@ export function removeUnusedRefs(
     return spec;
   }
 
-  for (const section of Object.keys(components)) {
+  /**
+   * Process only references inside `schemas` property since the main purpose of this function is
+   * to remove unreferenced Input and Output schemas used by zod
+   * @see https://github.com/marcalexiei/fastify-type-provider-zod/issues/38
+   */
+  const keysToProcess = ['schemas'];
+
+  for (const section of keysToProcess) {
     const items = components[section] as Record<string, unknown>;
     if (!items) {
       continue;

--- a/test/__snapshots__/fastify-swagger.spec.ts.snap
+++ b/test/__snapshots__/fastify-swagger.spec.ts.snap
@@ -1041,3 +1041,84 @@ exports[`transformer > should not generate ref 1`] = `
   "servers": [],
 }
 `;
+
+exports[`transformer > should not remove securitySchemes from the final openAPI object 1`] = `
+{
+  "components": {
+    "schemas": {
+      "User": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "format": "date-time",
+            "type": "string",
+          },
+          "id": {
+            "default": "1",
+            "type": "string",
+          },
+        },
+        "required": [
+          "id",
+          "createdAt",
+        ],
+        "type": "object",
+      },
+      "UserInput": {
+        "properties": {
+          "createdAt": {},
+          "id": {
+            "default": "1",
+            "type": "string",
+          },
+        },
+        "required": [
+          "createdAt",
+        ],
+        "type": "object",
+      },
+    },
+    "securitySchemes": {
+      "authorization": {
+        "bearerFormat": "JWT",
+        "scheme": "bearer",
+        "type": "http",
+      },
+    },
+  },
+  "info": {
+    "description": "Sample backend service",
+    "title": "SampleApi",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.3",
+  "paths": {
+    "/": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserInput",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User",
+                },
+              },
+            },
+            "description": "Default Response",
+          },
+        },
+      },
+    },
+  },
+  "servers": [],
+}
+`;

--- a/test/fastify-swagger.spec.ts
+++ b/test/fastify-swagger.spec.ts
@@ -654,6 +654,72 @@ describe('transformer', () => {
     await expect(openApiSpec).toBeValidOpenAPISchema();
   });
 
+  it('should not remove securitySchemes from the final openAPI object', async () => {
+    const app = Fastify();
+    app.setValidatorCompiler(validatorCompiler);
+    app.setSerializerCompiler(serializerCompiler);
+
+    const schemaRegistry = z.registry<{ id: string }>();
+
+    const USER_SCHEMA = z.object({
+      id: z.string().default('1'),
+      createdAt: z.date(),
+    });
+
+    schemaRegistry.add(USER_SCHEMA, { id: 'User' });
+
+    app.register(fastifySwagger, {
+      openapi: {
+        info: {
+          title: 'SampleApi',
+          description: 'Sample backend service',
+          version: '1.0.0',
+        },
+        components: {
+          securitySchemes: {
+            authorization: {
+              type: 'http',
+              scheme: 'bearer',
+              bearerFormat: 'JWT',
+            },
+          },
+        },
+        servers: [],
+      },
+      transform: createJsonSchemaTransform({ schemaRegistry }),
+      transformObject: createJsonSchemaTransformObject({ schemaRegistry }),
+    });
+
+    app.register(fastifySwaggerUI, {
+      routePrefix: '/documentation',
+    });
+
+    app.after(() => {
+      app.withTypeProvider<ZodTypeProvider>().route({
+        method: 'POST',
+        url: '/',
+        schema: {
+          body: USER_SCHEMA,
+          response: { 200: USER_SCHEMA },
+        },
+        handler: (_, res) => {
+          res.send({
+            id: undefined,
+            createdAt: new Date(0),
+          });
+        },
+      });
+    });
+
+    await app.ready();
+
+    const openApiSpecResponse = await app.inject().get('/documentation/json');
+    const openApiSpec = openApiSpecResponse.json();
+
+    expect(openApiSpec).toMatchSnapshot();
+    await expect(openApiSpec).toBeValidOpenAPISchema();
+  });
+
   describe('null type', () => {
     const createNullCaseApp = (): FastifyInstance => {
       const app = Fastify();


### PR DESCRIPTION
- closes #38

---

`removeUnusedSchemaRefs` was too eager. Now it only process references inside `components.schemas`.
Maybe prune operation can be useful for other keys but they can be easily added in the future.

Just integrate `keysToProcess` inside `removeUnusedSchemaRefs`

